### PR TITLE
feat: Implement robust ETL metrics collection and logging

### DIFF
--- a/src/py_load_medgen/cli.py
+++ b/src/py_load_medgen/cli.py
@@ -149,21 +149,6 @@ ETL_CONFIG: list[EtlFileConfig] = [
 ]
 
 
-# --- Helper for counting records in a stream ---
-T = TypeVar("T")
-
-
-class Counter:
-    value: int = 0
-
-
-def count_iterator(iterator: Iterator[T], counter: Counter) -> Iterator[T]:
-    """Wraps an iterator to count the number of items yielded."""
-    for item in iterator:
-        counter.value += 1
-        yield item
-
-
 def main():
     """Main CLI entry point for the MedGen ETL tool."""
     parser = argparse.ArgumentParser(
@@ -273,55 +258,58 @@ def main():
 
             for config in ETL_CONFIG:
                 local_path = local_file_paths[config["file"]]
+                table_metrics = {
+                    "table_name": config["prod_table"],
+                    "records_extracted": 0,
+                    "records_inserted": 0,
+                    "records_updated": 0,
+                    "records_deleted": 0,
+                }
 
                 logging.info(
                     f"--- Starting ETL for {config['file']} -> "
                     f"{config['prod_table']} ---"
                 )
 
-                # A. Initialize Staging
+                # 1. Initialize Staging
                 loader.initialize_staging(
                     config["staging_table"], config["staging_ddl"]
                 )
 
-                # B. Parse, Transform, and Load
+                # 2. Parse, Transform, and Load into Staging
                 logging.info(f"Opening and parsing {local_path}...")
-                record_counter = Counter()
                 f = None
                 try:
                     parser_func = config["parser"]
+                    # Determine how to open the file (gzipped or plain text)
                     if config["file"].endswith(".gz"):
-                        # For gzipped files, the parser function takes the path
                         records_iterator = parser_func(
                             local_path, max_errors=args.max_parse_errors
                         )
                     else:
-                        # For plain text files, the parser takes a file stream
                         f = open(local_path, "r", encoding="utf-8")
                         records_iterator = parser_func(
                             f, max_errors=args.max_parse_errors
                         )
 
-                    counted_records = count_iterator(records_iterator, record_counter)
-                    byte_iterator = config["transformer"](counted_records)
-                    loader.bulk_load(config["staging_table"], byte_iterator)
-
-                    logging.info(
-                        f"Finished loading data into {config['staging_table']}."
+                    # Transform records to bytes and load, capturing the count
+                    byte_iterator = config["transformer"](records_iterator)
+                    extracted_count = loader.bulk_load(
+                        config["staging_table"], byte_iterator
                     )
+                    table_metrics["records_extracted"] = extracted_count
+                    total_records_extracted += extracted_count
                     logging.info(
-                        f"Extracted and loaded {record_counter.value} records."
+                        f"Extracted and staged {extracted_count} records."
                     )
-                    total_records_extracted += record_counter.value
-                    total_records_loaded += record_counter.value
-
                 finally:
                     if f:
                         f.close()
 
-                # C. Apply Changes based on mode and log details
+                # 3. Apply Changes to Production and Capture Metrics
+                apply_metrics = {}
                 if args.mode == "full":
-                    loader.apply_changes(
+                    apply_metrics = loader.apply_changes(
                         mode="full",
                         staging_table=config["staging_table"],
                         production_table=config["prod_table"],
@@ -330,33 +318,16 @@ def main():
                         pk_name=config["prod_pk"],
                         full_load_select_sql=config.get("full_load_select_sql"),
                     )
-                    # For full loads, extracted equals inserted
-                    metrics = {
-                        "table_name": config["prod_table"],
-                        "records_extracted": record_counter.value,
-                        "records_inserted": record_counter.value,
-                        "records_deleted": 0,
-                        "records_updated": 0,
-                    }
-                    loader.log_run_detail(log_id, metrics)
-
                 elif args.mode == "delta":
-                    cdc_metrics = loader.execute_cdc(
+                    # First, run CDC to identify changes
+                    loader.execute_cdc(
                         staging_table=config["staging_table"],
                         production_table=config["prod_table"],
                         pk_name=config["prod_pk"],
                         business_key=config["business_key"],
                     )
-                    # For delta loads, log CDC results
-                    metrics = {
-                        "table_name": config["prod_table"],
-                        "records_extracted": record_counter.value,
-                        "records_inserted": cdc_metrics.get("inserts", 0),
-                        "records_deleted": cdc_metrics.get("deletes", 0),
-                        "records_updated": cdc_metrics.get("updates", 0),
-                    }
-                    loader.log_run_detail(log_id, metrics)
-                    loader.apply_changes(
+                    # Then, apply the identified changes
+                    apply_metrics = loader.apply_changes(
                         mode="delta",
                         staging_table=config["staging_table"],
                         production_table=config["prod_table"],
@@ -366,6 +337,18 @@ def main():
                         business_key=config["business_key"],
                     )
 
+                # 4. Update and Log Detailed Metrics
+                table_metrics["records_inserted"] = apply_metrics.get("inserted", 0)
+                table_metrics["records_updated"] = apply_metrics.get("updated", 0)
+                table_metrics["records_deleted"] = apply_metrics.get("deleted", 0)
+                loader.log_run_detail(log_id, table_metrics)
+
+                # 5. Aggregate Total Loaded Records for the Final Summary
+                # "Loaded" means a record is new or changed in the production table.
+                total_records_loaded += table_metrics["records_inserted"]
+                total_records_loaded += table_metrics["records_updated"]
+
+                # 6. Cleanup Staging and Backup Tables
                 loader.cleanup(config["staging_table"], config["prod_table"])
 
             # 4. Log success if we reached the end

--- a/src/py_load_medgen/loader/postgres.py
+++ b/src/py_load_medgen/loader/postgres.py
@@ -105,19 +105,26 @@ class PostgresNativeLoader(AbstractNativeLoader):
         self._commit()
         logging.info(f"Staging table {table_name} initialized successfully.")
 
-    def bulk_load(self, table_name: str, data_iterator: Iterator[bytes]) -> None:
-        """Executes a native, high-performance bulk load operation using COPY."""
+    def bulk_load(self, table_name: str, data_iterator: Iterator[bytes]) -> int:
+        """
+        Executes a native, high-performance bulk load operation using COPY.
+        Returns:
+            The number of rows loaded into the staging table.
+        """
         if not self.conn:
             raise ConnectionError("Database connection not established.")
         logging.info(f"Starting bulk load into '{table_name}'...")
+        rowcount = 0
         with self.conn.cursor() as cur:
             with cur.copy(
                 f"COPY {table_name} FROM STDIN WITH (FORMAT TEXT, NULL '\\N')"
             ) as copy:
                 for line in data_iterator:
                     copy.write(line)
+            rowcount = cur.rowcount
         self._commit()
-        logging.info(f"Bulk load into '{table_name}' complete.")
+        logging.info(f"Bulk load into '{table_name}' complete. Loaded {rowcount} rows.")
+        return rowcount
 
     def _initialize_metadata(self) -> None:
         """Ensures the ETL audit log tables exist."""
@@ -378,10 +385,14 @@ class PostgresNativeLoader(AbstractNativeLoader):
         pk_name: str,
         business_key: Optional[str] = None,
         full_load_select_sql: Optional[str] = None,
-    ) -> None:
-        """Applies changes to the production table based on the load mode."""
+    ) -> dict[str, int]:
+        """
+        Applies changes to the production table based on the load mode.
+        Returns:
+            A dictionary with the counts of inserted, updated, and deleted records.
+        """
         if mode == "full":
-            self._apply_full_load(
+            return self._apply_full_load(
                 staging_table,
                 production_table,
                 production_ddl,
@@ -390,7 +401,7 @@ class PostgresNativeLoader(AbstractNativeLoader):
         elif mode == "delta":
             if not business_key:
                 raise ValueError("A 'business_key' is required for delta loads.")
-            self._apply_delta_load(
+            return self._apply_delta_load(
                 production_table, pk_name, business_key, production_ddl, index_ddls
             )
         else:
@@ -402,13 +413,19 @@ class PostgresNativeLoader(AbstractNativeLoader):
         production_table: str,
         production_ddl: str,
         full_load_select_sql: Optional[str] = None,
-    ) -> None:
-        """Applies changes atomically using the 'atomic swap' method for a full load."""
+    ) -> dict[str, int]:
+        """
+        Applies changes atomically using the 'atomic swap' method for a full load.
+        Returns:
+            A dictionary with the count of inserted records.
+        """
         if not self.conn:
             raise ConnectionError("Database connection not established.")
         new_production_table = f"{production_table}_new"
         backup_table = f"{production_table}_old"
         index_ddls = self._get_table_indexes(production_table)
+        inserted_count = 0
+
         logging.info(
             f"Applying FULL load for table {production_table} with atomic swap..."
         )
@@ -416,7 +433,6 @@ class PostgresNativeLoader(AbstractNativeLoader):
             cur.execute(production_ddl.format(table_name=new_production_table))
 
             if full_load_select_sql:
-                # Use custom SQL for loading data from staging to production
                 insert_sql = full_load_select_sql.format(
                     new_production_table=new_production_table,
                     staging_table=staging_table,
@@ -425,15 +441,15 @@ class PostgresNativeLoader(AbstractNativeLoader):
                     f"Loading data into '{new_production_table}' using custom SQL..."
                 )
                 cur.execute(insert_sql)
+                inserted_count = cur.rowcount
             else:
-                # Use generic SELECT * for tables with matching schemas
                 cur.execute(
                     "SELECT column_name FROM information_schema.columns "
                     "WHERE table_name = %s ORDER BY ordinal_position;",
                     (staging_table,),
                 )
                 columns = [row[0] for row in cur.fetchall()]
-                column_list_str = ", ".join(columns)
+                column_list_str = ", ".join(f'"{col}"' for col in columns)
                 logging.info(
                     f"Loading data from '{staging_table}' into '{new_production_table}'"
                 )
@@ -441,6 +457,7 @@ class PostgresNativeLoader(AbstractNativeLoader):
                     f"INSERT INTO {new_production_table} ({column_list_str}) "
                     f"SELECT {column_list_str} FROM {staging_table};"
                 )
+                inserted_count = cur.rowcount
 
             logging.info(
                 f"Replicating {len(index_ddls)} indexes on "
@@ -454,6 +471,7 @@ class PostgresNativeLoader(AbstractNativeLoader):
                     else index_ddl.replace(production_table, new_production_table)
                 )
                 cur.execute(replicated_ddl)
+
             logging.info("Performing atomic swap in a single transaction...")
             with self.conn.transaction():
                 cur.execute(f"DROP TABLE IF EXISTS {backup_table} CASCADE;")
@@ -464,10 +482,12 @@ class PostgresNativeLoader(AbstractNativeLoader):
                 cur.execute(
                     f"ALTER TABLE {new_production_table} RENAME TO {production_table};"
                 )
+
         logging.info(
             f"Atomic swap complete for {production_table}. "
-            "Production data is updated."
+            f"Inserted {inserted_count} records."
         )
+        return {"inserted": inserted_count, "updated": 0, "deleted": 0}
 
     def _apply_delta_load(
         self,
@@ -476,11 +496,18 @@ class PostgresNativeLoader(AbstractNativeLoader):
         business_key: str,
         production_ddl: str,
         index_ddls: list[str],
-    ) -> None:
-        """Applies inserts, updates, and soft deletes for a delta load."""
+    ) -> dict[str, int]:
+        """
+        Applies inserts, updates, and soft deletes for a delta load.
+        Returns:
+            A dictionary with the counts of inserted, updated, and deleted records.
+        """
         if not self.conn:
             raise ConnectionError("Database connection not established.")
+
+        metrics = {"inserted": 0, "updated": 0, "deleted": 0}
         logging.info(f"Applying DELTA load for table {production_table}...")
+
         with self.conn.cursor() as cur:
             # Ensure production table and indexes exist
             cur.execute("SELECT to_regclass(%s)", (production_table,))
@@ -494,8 +521,6 @@ class PostgresNativeLoader(AbstractNativeLoader):
                     cur.execute(index_ddl.format(table_name=production_table))
                 logging.info(f"Table '{production_table}' and its indexes created.")
 
-            # --- Get columns for the UPDATE statement ---
-            # Exclude PK and business key columns from the SET clause
             business_key_cols = {key.strip() for key in business_key.split(",")}
             cur.execute(
                 "SELECT column_name FROM information_schema.columns "
@@ -506,9 +531,6 @@ class PostgresNativeLoader(AbstractNativeLoader):
             update_columns = [
                 row[0] for row in cur.fetchall() if row[0] not in business_key_cols
             ]
-
-            # --- Get columns for the INSERT statement ---
-            # Exclude only the PK for inserts
             cur.execute(
                 "SELECT column_name FROM information_schema.columns "
                 "WHERE table_name = 'cdc_inserts' AND column_name != %s "
@@ -525,18 +547,17 @@ class PostgresNativeLoader(AbstractNativeLoader):
                         [f'"{col}" = s."{col}"' for col in update_columns]
                     )
                     set_clause += ", last_updated_at = NOW()"
-
                     keys = [key.strip() for key in business_key.split(",")]
                     join_condition = " AND ".join(
                         [f'p."{key}" = s."{key}"' for key in keys]
                     )
-
                     sql_update = (
                         f"UPDATE {production_table} p SET {set_clause} "
                         f"FROM cdc_updates s WHERE {join_condition};"
                     )
                     cur.execute(sql_update)
-                    logging.info(f"Applied {cur.rowcount} updates.")
+                    metrics["updated"] = cur.rowcount
+                    logging.info(f"Applied {metrics['updated']} updates.")
 
                 # 2. Apply Deletes
                 sql_delete = (
@@ -545,7 +566,8 @@ class PostgresNativeLoader(AbstractNativeLoader):
                     f"IN (SELECT id FROM cdc_deletes);"
                 )
                 cur.execute(sql_delete)
-                logging.info(f"Applied {cur.rowcount} soft deletes.")
+                metrics["deleted"] = cur.rowcount
+                logging.info(f"Applied {metrics['deleted']} soft deletes.")
 
                 # 3. Apply Inserts
                 if insert_columns:
@@ -554,9 +576,11 @@ class PostgresNativeLoader(AbstractNativeLoader):
                         f"SELECT {insert_column_list_str} FROM cdc_inserts;"
                     )
                     cur.execute(sql_insert)
-                    logging.info(f"Applied {cur.rowcount} inserts.")
+                    metrics["inserted"] = cur.rowcount
+                    logging.info(f"Applied {metrics['inserted']} inserts.")
 
         logging.info(f"Delta load for {production_table} complete.")
+        return metrics
 
     def cleanup(self, staging_table: str, production_table: str) -> None:
         """Performs cleanup operations by dropping old backup and staging tables."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,182 @@
+import gzip
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from py_load_medgen.cli import ETL_CONFIG
+from py_load_medgen.cli import main as cli_main
+from py_load_medgen.loader.postgres import PostgresNativeLoader
+
+# Mark all tests in this file as integration tests
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="function")
+def medgen_data_dir(tmp_path: Path) -> Path:
+    """Creates a temporary directory with mock MedGen data files for testing."""
+    # --- Version 1 Data ---
+    v1_dir = tmp_path / "v1"
+    v1_dir.mkdir()
+    # Mock MRCONSO.RRF with the correct number of columns (18).
+    # Added a final pipe to each line to create the 18th empty column (CVF).
+    mrconso_v1_content = [
+        "C0000001|ENG|P|L0000001|PF|S0000001|Y|A0000001||||OMIM|PT|100650|OMIM:100650|0|N||",
+        "C0000002|ENG|P|L0000002|PF|S0000002|Y|A0000002||||OMIM|PT|100700|OMIM:100700|0|N||",
+        "C0000003|ENG|P|L0000003|PF|S0000003|Y|A0000003||||OMIM|PT|100800|OMIM:100800|0|N||",
+    ]
+    with open(v1_dir / "MRCONSO.RRF", "w", encoding="utf-8") as f:
+        f.write("\n".join(mrconso_v1_content) + "\n")
+
+    # --- Version 2 Data (for Delta Load) ---
+    v2_dir = tmp_path / "v2"
+    v2_dir.mkdir()
+    # A0000001: Unchanged, A0000002: Deleted, A0000003: Updated, A0000004: Inserted
+    mrconso_v2_content = [
+        "C0000001|ENG|P|L0000001|PF|S0000001|Y|A0000001||||OMIM|PT|100650|OMIM:100650|0|N||",
+        "C0000003|ENG|P|L0000003|PF|S0000003|Y|A0000003||||OMIM|PT|100800-updated|OMIM:100800|0|N||",
+        "C0000004|ENG|P|L0000004|PF|S0000004|Y|A0000004||||OMIM|PT|100900|OMIM:100900|0|N||",
+    ]
+    with open(v2_dir / "MRCONSO.RRF", "w", encoding="utf-8") as f:
+        f.write("\n".join(mrconso_v2_content) + "\n")
+
+    return tmp_path
+
+
+@pytest.fixture
+def mock_downloader_and_config(monkeypatch):
+    """
+    Mocks the Downloader and isolates the ETL_CONFIG to only run the
+    MRCONSO.RRF -> medgen_concepts ETL step.
+    """
+    # Isolate the config to only the part we are testing
+    mrconso_config = next(c for c in ETL_CONFIG if c["file"] == "MRCONSO.RRF")
+    monkeypatch.setattr("py_load_medgen.cli.ETL_CONFIG", [mrconso_config])
+
+    # Mock the downloader methods
+    monkeypatch.setattr("py_load_medgen.cli.Downloader.__enter__", lambda self: self)
+    monkeypatch.setattr("py_load_medgen.cli.Downloader.__exit__", lambda self, exc_type, exc_val, exc_tb: None)
+    monkeypatch.setattr("py_load_medgen.cli.Downloader.get_release_version", lambda self: "test_release_version")
+    monkeypatch.setattr("py_load_medgen.cli.Downloader.list_files", lambda self: ["MRCONSO.RRF"])
+    monkeypatch.setattr("py_load_medgen.cli.Downloader.get_checksums", lambda self, filename: {})
+    monkeypatch.setattr("py_load_medgen.cli.Downloader.download_file", lambda self, remote, local, checksums: None)
+
+
+def run_cli(monkeypatch, args: list[str]):
+    """Helper to run the CLI main function with mocked sys.argv and sys.exit."""
+    monkeypatch.setattr(sys, "argv", ["py_load_medgen"] + args)
+    try:
+        cli_main()
+    except SystemExit as e:
+        assert e.code == 0, f"CLI exited with non-zero code: {e.code}"
+
+
+def test_full_load_metrics(
+    postgres_db_dsn: str, medgen_data_dir: Path, monkeypatch, mock_downloader_and_config
+):
+    """
+    Tests that a full load correctly populates the metrics in the audit tables.
+    """
+    run_cli(
+        monkeypatch,
+        [
+            "--db-dsn",
+            postgres_db_dsn,
+            "--mode",
+            "full",
+            "--download-dir",
+            str(medgen_data_dir / "v1"),
+        ],
+    )
+
+    # --- Verification ---
+    with PostgresNativeLoader(db_dsn=postgres_db_dsn) as loader:
+        with loader.conn.cursor() as cur:
+            cur.execute(
+                "SELECT log_id, status, records_extracted, records_loaded "
+                "FROM etl_audit_log ORDER BY start_time DESC LIMIT 1"
+            )
+            result = cur.fetchone()
+            assert result is not None
+            log_id, status, total_extracted, total_loaded = result
+
+            assert status == "Succeeded"
+            assert total_extracted == 3
+            assert total_loaded == 3
+
+            cur.execute(
+                "SELECT records_extracted, records_inserted, records_updated, records_deleted "
+                "FROM etl_run_details WHERE log_id = %s AND table_name = 'medgen_concepts'",
+                (log_id,),
+            )
+            detail_result = cur.fetchone()
+            assert detail_result is not None
+            extracted, inserted, updated, deleted = detail_result
+
+            assert extracted == 3
+            assert inserted == 3
+            assert updated == 0
+            assert deleted == 0
+
+
+def test_delta_load_metrics(
+    postgres_db_dsn: str, medgen_data_dir: Path, monkeypatch, mock_downloader_and_config
+):
+    """
+    Tests that a delta load correctly identifies and logs inserts, updates,
+    and deletes.
+    """
+    # --- Phase 1: Run initial FULL load ---
+    run_cli(
+        monkeypatch,
+        [
+            "--db-dsn",
+            postgres_db_dsn,
+            "--mode",
+            "full",
+            "--download-dir",
+            str(medgen_data_dir / "v1"),
+        ],
+    )
+
+    # --- Phase 2: Run DELTA load with updated data ---
+    run_cli(
+        monkeypatch,
+        [
+            "--db-dsn",
+            postgres_db_dsn,
+            "--mode",
+            "delta",
+            "--download-dir",
+            str(medgen_data_dir / "v2"),
+        ],
+    )
+
+    # --- Verification ---
+    with PostgresNativeLoader(db_dsn=postgres_db_dsn) as loader:
+        with loader.conn.cursor() as cur:
+            cur.execute(
+                "SELECT log_id, status, records_extracted, records_loaded "
+                "FROM etl_audit_log ORDER BY start_time DESC LIMIT 1"
+            )
+            result = cur.fetchone()
+            assert result is not None
+            log_id, status, total_extracted, total_loaded = result
+
+            assert status == "Succeeded"
+            assert total_extracted == 3
+            assert total_loaded == 2  # 1 insert + 1 update
+
+            cur.execute(
+                "SELECT records_extracted, records_inserted, records_updated, records_deleted "
+                "FROM etl_run_details WHERE log_id = %s AND table_name = 'medgen_concepts'",
+                (log_id,),
+            )
+            detail_result = cur.fetchone()
+            assert detail_result is not None
+            extracted, inserted, updated, deleted = detail_result
+
+            assert extracted == 3
+            assert inserted == 1
+            assert updated == 1
+            assert deleted == 1


### PR DESCRIPTION
This commit implements accurate and comprehensive metrics collection for the MedGen ETL process, fulfilling requirement R-2.4.4 from the FRD.

The key changes are:
1.  The `PostgresNativeLoader`'s write operations (`apply_changes`, `_apply_full_load`, `_apply_delta_load`) now return a dictionary containing the precise number of records inserted, updated, and deleted, as reported by the database cursor's `rowcount`.
2.  The `bulk_load` method now returns the number of records successfully loaded into the staging table.
3.  The main CLI orchestrator in `cli.py` has been refactored to use these returned metrics. It correctly calculates the `records_extracted` and aggregates the `records_loaded` (inserts + updates) for the summary log.
4.  The per-table detail logs (`etl_run_details`) are now populated with the accurate metrics returned from the loader.
5.  A new integration test module, `tests/test_metrics.py`, has been added to validate the correctness of the metrics for both 'full' and 'delta' load modes against a live database.
6.  The test suite was improved to isolate the metrics tests from pre-existing bugs in other parts of the ETL pipeline.