### PR TITLE
feat: Make parsers resilient to whitespace

### DIFF
--- a/src/py_load_medgen/parser.py
+++ b/src/py_load_medgen/parser.py
@@ -123,7 +123,7 @@ def parse_mrconso(file_stream: IO[str], max_errors: int) -> Iterator[MrconsoReco
         if not raw_line:
             continue
 
-        row = raw_line.split("|")
+        row = [field.strip() for field in raw_line.split("|")]
         if len(
             row
         ) < 19:  # A valid RRF row with 18 fields will have 19 elements after
@@ -192,7 +192,7 @@ def parse_names(file_path: Path, max_errors: int) -> Iterator[MedgenName]:
             if not raw_line:
                 continue
 
-            row = raw_line.split("|")
+            row = [field.strip() for field in raw_line.split("|")]
             if len(row) < 5:
                 error_count += 1
                 logging.warning(
@@ -238,7 +238,7 @@ def parse_hpo_mapping(file_path: Path, max_errors: int) -> Iterator[MedgenHpoMap
             if not raw_line:
                 continue
 
-            row = raw_line.split("\t")
+            row = [field.strip() for field in raw_line.split("\t")]
             if len(row) != 6:
                 error_count += 1
                 logging.warning(
@@ -315,7 +315,7 @@ def parse_mrrel(file_stream: IO[str], max_errors: int) -> Iterator[MrrelRecord]:
         if not raw_line:
             continue
 
-        row = raw_line.split("|")
+        row = [field.strip() for field in raw_line.split("|")]
         if len(row) < 17:
             error_count += 1
             logging.warning(
@@ -402,7 +402,7 @@ def parse_mrsty(file_stream: IO[str], max_errors: int) -> Iterator[MrstyRecord]:
         if not raw_line:
             continue
 
-        row = raw_line.split("|")
+        row = [field.strip() for field in raw_line.split("|")]
         if len(row) < 7:
             error_count += 1
             logging.warning(
@@ -486,7 +486,7 @@ def parse_mrsat(file_stream: IO[str], max_errors: int) -> Iterator[MrsatRecord]:
         if not raw_line:
             continue
 
-        row = raw_line.split("|")
+        row = [field.strip() for field in raw_line.split("|")]
         # A valid RRF row with 13 fields will have 14 elements after splitting on
         # the trailing pipe
         if len(row) < 14:

--- a/tests/test_parser_resilience.py
+++ b/tests/test_parser_resilience.py
@@ -1,0 +1,36 @@
+import io
+import pytest
+from py_load_medgen.parser import parse_mrconso, MrconsoRecord
+
+def test_parse_mrconso_handles_whitespace():
+    """
+    Tests that the MRCONSO parser is resilient to leading/trailing whitespace
+    in fields.
+    """
+    # Note the extra spaces around the pipe delimiters and within the fields
+    mock_data = (
+        " C0000005 | ENG |P|L0000005|PF|S0007492|Y|A28464245| | | |MTH|PN|"
+        " A-2-beta-glycoprotein-I | alpha-2-glycoprotein I |0|N|256||\n"
+    )
+    mock_file = io.StringIO(mock_data)
+
+    # Parse the mock data
+    parser = parse_mrconso(mock_file, max_errors=0)
+    records = list(parser)
+
+    # Assert that one record was parsed
+    assert len(records) == 1
+    record = records[0]
+
+    # Assert that the fields were correctly stripped of whitespace
+    assert record.cui == "C0000005"
+    assert record.lat == "ENG"
+    assert record.ispref == "Y"
+    assert record.code == "A-2-beta-glycoprotein-I"
+    assert record.record_str == "alpha-2-glycoprotein I"
+    assert record.sab == "MTH"
+    # The raw_record should remain untouched, with original whitespace
+    assert record.raw_record == (
+        "C0000005 | ENG |P|L0000005|PF|S0007492|Y|A28464245| | | |MTH|PN|"
+        " A-2-beta-glycoprotein-I | alpha-2-glycoprotein I |0|N|256||"
+    )


### PR DESCRIPTION
The parsers for the MedGen data files were not resilient to extraneous leading or trailing whitespace in the data fields. The implementation used `line.strip().split('|')`, which only strips the line as a whole, not the individual fields. This could lead to subtle data corruption or downstream errors if the source files contain such variations.

This change modifies all six parsing functions in `parser.py` to use a list comprehension (`[field.strip() for field in ...]`) to ensure each field is stripped of whitespace immediately after the line is split.

This change fulfills requirement R-2.2.2 of the FRD.

A new unit test has been added in `tests/test_parser_resilience.py` to specifically verify this new behavior.