### PR TITLE
feat(testing): Add unit test for HPO mapping parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,9 +3,11 @@ import io
 from pathlib import Path
 
 from py_load_medgen.parser import (
+    MedgenHpoMapping,
     MedgenName,
     MrconsoRecord,
     MrstyRecord,
+    parse_hpo_mapping,
     parse_mrconso,
     parse_mrsty,
     parse_names,
@@ -26,7 +28,7 @@ def test_parse_names_and_raw_record(tmp_path: Path):
         "C0000731|Abdominal distention|GTR|Y|",  # Suppressed
         "C0000734|Abdominal mass|GTR|N|",
         "C0000735||GTR|N|",  # Valid row with empty name
-        "C0000736|Missing pipe", # Malformed row
+        "C0000736|Missing pipe",  # Malformed row
     ]
     with gzip.open(file_path, "wt", encoding="utf-8") as f:
         f.write("\n".join(content_lines))
@@ -66,6 +68,53 @@ def test_parse_names_and_raw_record(tmp_path: Path):
     )
     assert records[4] == MedgenName(
         cui="C0000735", name="", source="GTR", suppress="N", raw_record=content_lines[5]
+    )
+
+
+def test_parse_hpo_mapping(tmp_path: Path):
+    """
+    Tests that the parse_hpo_mapping function correctly parses a gzipped,
+    tab-delimited MedGen_HPO_Mapping.txt.gz file.
+    """
+    # 1. Arrange: Create a dummy gzipped MedGen_HPO_Mapping.txt.gz file
+    file_path = tmp_path / "MedGen_HPO_Mapping.txt.gz"
+    # Based on FTP_README.txt, the columns are:
+    # CUI, SDUI, HpoStr, MedGenStr, MedGenStr_SAB, STY
+    content_lines = [
+        "#CUI\tSDUI\tHpoStr\tMedGenStr\tMedGenStr_SAB\tSTY",
+        "C0000768\tHP:0002164\tAbducens palsy\tAbducens palsy\tHPO\tFinding",
+        "C0001261\tHP:0000522\tAlacrima\tAlacrima\tHPO\tFinding",
+        "C0001261\tHP:0007784\tAbsent lacrimal punctum\tAbsent lacrimal punctum\tHPO\tFinding",
+        "C0001439\tHP:0001290\tAphasia\tAphasia\tHPO\tFinding",
+        "C0001439\tHP:00024Aphasia\tAphasia\tHPO\tFinding",  # Malformed row (missing tab)
+    ]
+    with gzip.open(file_path, "wt", encoding="utf-8") as f:
+        f.write("\n".join(content_lines))
+
+    # 2. Act: Parse the file, allowing for some errors
+    records = list(parse_hpo_mapping(file_path, max_errors=10))
+
+    # 3. Assert
+    assert len(records) == 4
+    assert records[0] == MedgenHpoMapping(
+        cui="C0000768",
+        sdui="HP:0002164",
+        hpo_str="Abducens palsy",
+        medgen_str="Abducens palsy",
+        medgen_str_sab="HPO",
+        sty="Finding",
+        raw_record=content_lines[1],
+    )
+    assert records[1].cui == "C0001261"
+    assert records[1].sdui == "HP:0000522"
+    assert records[3] == MedgenHpoMapping(
+        cui="C0001439",
+        sdui="HP:0001290",
+        hpo_str="Aphasia",
+        medgen_str="Aphasia",
+        medgen_str_sab="HPO",
+        sty="Finding",
+        raw_record=content_lines[4],
     )
 
 
@@ -128,10 +177,10 @@ def test_parse_mrsty():
     content_lines = [
         "C0000052|T029|B1.2.1.2.1|Body Part, Organ, or Organ Component|||",
         "C0000052|T060|B2.2.1.2|Diagnostic Procedure|||",
-        "C0000074|T033|B1.2.1.1|Finding|AT12345|CVF123|", # All fields present
+        "C0000074|T033|B1.2.1.1|Finding|AT12345|CVF123|",  # All fields present
         "C0000074|T047|B2.2.1.2.1|Disease or Syndrome|||",
         "C0000097|T121|B4|Pharmacologic Substance|||",
-        "C0000102|T061|B2.2.1.2.2|Therapeutic or Preventive Procedure", # Malformed row
+        "C0000102|T061|B2.2.1.2.2|Therapeutic or Preventive Procedure",  # Malformed row
     ]
     file_stream = io.StringIO("\n".join(content_lines))
 


### PR DESCRIPTION
This change introduces a unit test for the `parse_hpo_mapping` function.

The implementation for this parser already existed in the codebase, but it lacked test coverage. This commit adds the necessary tests to validate the parser's correctness and error handling, ensuring the reliability of the HPO data ingestion process.