### PR TITLE
feat: Add structured JSON logging

### DIFF
--- a/src/py_load_medgen/cli.py
+++ b/src/py_load_medgen/cli.py
@@ -45,10 +45,42 @@ from py_load_medgen.sql.ddl import (
     STAGING_SEMANTIC_TYPES_DDL,
 )
 
+from py_load_medgen.logging import JsonFormatter
+
+def setup_logging():
+    """
+    Configures logging based on the LOG_FORMAT environment variable.
+    Defaults to standard text-based logging. If LOG_FORMAT=json, uses
+    structured JSON logging.
+    """
+    log_format = os.environ.get("LOG_FORMAT", "text").lower()
+
+    # Get the root logger
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    # Remove any existing handlers
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    # Create a new handler
+    handler = logging.StreamHandler(sys.stdout)
+
+    if log_format == "json":
+        formatter = JsonFormatter()
+        handler.setFormatter(formatter)
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+
+    root_logger.addHandler(handler)
+
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
+# logging.basicConfig(
+#     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+# )
 
 # --- Constants ---
 NCBI_FTP_HOST = "ftp.ncbi.nlm.nih.gov"
@@ -151,6 +183,7 @@ ETL_CONFIG: list[EtlFileConfig] = [
 
 def main():
     """Main CLI entry point for the MedGen ETL tool."""
+    setup_logging()
     parser = argparse.ArgumentParser(
         description="A CLI tool for loading NCBI MedGen data into a database."
     )

--- a/src/py_load_medgen/logging.py
+++ b/src/py_load_medgen/logging.py
@@ -1,0 +1,52 @@
+import json
+import logging
+from datetime import datetime, timezone
+
+
+class JsonFormatter(logging.Formatter):
+    """
+    A custom logging formatter that outputs log records as JSON strings.
+    This formatter ensures that logs are structured and machine-readable,
+    which is ideal for modern observability platforms.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Formats a log record into a JSON string.
+        Args:
+            record: The LogRecord instance to format.
+        Returns:
+            A JSON string representing the log record.
+        """
+        # Base attributes from the LogRecord
+        log_object = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Include exception information if it exists
+        if record.exc_info:
+            log_object["exception"] = self.formatException(record.exc_info)
+
+        # Include stack information if it exists
+        if record.stack_info:
+            log_object["stack_info"] = self.formatStack(record.stack_info)
+
+        # Add any extra fields passed to the logger
+        # Standard LogRecord attributes to exclude from the 'extra' dictionary
+        standard_attrs = {
+            "args", "asctime", "created", "exc_info", "exc_text", "filename",
+            "funcName", "levelname", "levelno", "lineno", "module", "msecs",
+            "message", "msg", "name", "pathname", "process", "processName",
+            "relativeCreated", "stack_info", "thread", "threadName"
+        }
+        extra_fields = {
+            key: value for key, value in record.__dict__.items()
+            if key not in standard_attrs and not key.startswith('_')
+        }
+        if extra_fields:
+            log_object["extra"] = extra_fields
+
+        return json.dumps(log_object)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,98 @@
+import json
+import logging
+import time
+
+from py_load_medgen.logging import JsonFormatter
+
+
+def test_json_formatter_basic():
+    """
+    Tests that the JsonFormatter correctly formats a basic log record into a
+    JSON string.
+    """
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname="/path/to/test.py",
+        lineno=10,
+        msg="This is a test message",
+        args=(),
+        exc_info=None,
+    )
+
+    # Simulate the time to ensure consistent timestamp output
+    record.created = time.time()
+
+    # Format the record
+    formatted_json = formatter.format(record)
+
+    # Parse the output and verify its contents
+    log_object = json.loads(formatted_json)
+
+    assert log_object["level"] == "INFO"
+    assert log_object["name"] == "test_logger"
+    assert log_object["message"] == "This is a test message"
+    assert "timestamp" in log_object
+
+
+def test_json_formatter_with_extra_fields():
+    """
+    Tests that the JsonFormatter includes extra fields provided in the log record.
+    """
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.WARNING,
+        pathname="/path/to/test.py",
+        lineno=20,
+        msg="Another test",
+        args=(),
+        exc_info=None,
+    )
+    # Add extra data to the record
+    record.extra_field_1 = "value1"
+    record.extra_field_2 = 123
+
+    # Format the record
+    formatted_json = formatter.format(record)
+
+    # Parse the output and verify its contents
+    log_object = json.loads(formatted_json)
+
+    assert log_object["level"] == "WARNING"
+    assert log_object["message"] == "Another test"
+    assert "extra" in log_object
+    assert log_object["extra"]["extra_field_1"] == "value1"
+    assert log_object["extra"]["extra_field_2"] == 123
+
+
+def test_json_formatter_with_exception():
+    """
+    Tests that the JsonFormatter correctly includes exception information.
+    """
+    formatter = JsonFormatter()
+    try:
+        raise ValueError("This is a test exception")
+    except ValueError as e:
+        # Create a log record with exception info
+        record = logging.LogRecord(
+            name="error_logger",
+            level=logging.ERROR,
+            pathname="/path/to/error.py",
+            lineno=30,
+            msg="An error occurred",
+            args=(),
+            exc_info=(type(e), e, e.__traceback__),
+        )
+
+    # Format the record
+    formatted_json = formatter.format(record)
+
+    # Parse the output and verify its contents
+    log_object = json.loads(formatted_json)
+
+    assert log_object["level"] == "ERROR"
+    assert log_object["message"] == "An error occurred"
+    assert "exception" in log_object
+    assert "ValueError: This is a test exception" in log_object["exception"]


### PR DESCRIPTION
This commit introduces structured JSON logging to the application, fulfilling requirement NFR-6.3.1 from the FRD.

The key changes include:
- A new `JsonFormatter` class in `py_load_medgen/logging.py` that formats log records into a machine-readable JSON format.
- The formatter includes standard log attributes, exception information, and any extra data passed to the logger.
- The main CLI in `py_load_medgen/cli.py` has been updated to use this new formatter when the `LOG_FORMAT=json` environment variable is set. This provides flexibility and maintains backward compatibility with the default text-based logging.
- Added unit tests for the `JsonFormatter` in `tests/test_logging.py` to ensure its correctness and handling of various logging scenarios (basic, with extra fields, and with exceptions).