### PR TITLE
feat: Add integration test for data type mismatch

### DIFF
--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -57,3 +57,50 @@ def test_bulk_load_handles_db_constraint_violation(
     with db_connection.cursor() as cur:
         records = _get_all_records(cur, staging_table)
         assert len(records) == 0
+
+
+def test_bulk_load_handles_data_type_mismatch(
+    loader: PostgresNativeLoader, db_connection: psycopg.Connection
+):
+    """
+    Tests that the bulk loader correctly handles a data type mismatch
+    (e.g., loading a string into an INT column) and rolls back the transaction.
+    FRD Alignment: R-4.2.1 (Error Handling), R-4.3.2 (Rollback)
+    """
+    staging_table = "staging_concepts_type_mismatch"
+
+    # DDL with an integer column `concept_id`
+    STAGING_CONCEPTS_DDL = """
+    CREATE TABLE {table_name} (
+        concept_id INTEGER,
+        cui TEXT NOT NULL,
+        name TEXT
+    );
+    """
+
+    # Data with a string value for the integer `concept_id` column.
+    BAD_CONCEPTS_DATA = [
+        ["101", "C0000001", "Name A"],
+        ["not_an_integer", "C0000002", "Name B"],
+        ["103", "C0000003", "Name C"],
+    ]
+
+    # 1. Initialize staging table
+    loader.initialize_staging(
+        staging_table, STAGING_CONCEPTS_DDL.format(table_name=staging_table)
+    )
+    db_connection.commit()
+
+    # 2. Attempt to bulk load the malformed data
+    with pytest.raises(psycopg.errors.InvalidTextRepresentation) as excinfo:
+        loader.bulk_load(staging_table, generate_tsv_stream(BAD_CONCEPTS_DATA))
+
+    # Check that the error message is for the correct data type violation
+    assert "invalid input syntax for type integer" in str(excinfo.value)
+    assert '"not_an_integer"' in str(excinfo.value)
+
+    # 3. Verify that the transaction was rolled back and the table is empty
+    db_connection.rollback()
+    with db_connection.cursor() as cur:
+        records = _get_all_records(cur, staging_table)
+        assert len(records) == 0


### PR DESCRIPTION
Adds a new integration test to verify that the bulk loader correctly handles data type mismatches during a PostgreSQL `COPY` operation.

This test simulates loading a string value into an integer column and asserts that:
1. The correct `psycopg.errors.InvalidTextRepresentation` exception is raised.
2. The database transaction is rolled back, leaving the target table empty.

This test improves the robustness of the error handling test suite by covering a different failure mode than the existing constraint violation test.